### PR TITLE
DAT-12 Add ProductTile component with Sling Model, HTL, tests, and Xerces dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -209,5 +209,12 @@ Import-Package: javax.annotation;version=0.0.0,*
             <version>1.4.4</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>2.12.2</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/com/aem/ford/core/models/ProductTile.java
+++ b/core/src/main/java/com/aem/ford/core/models/ProductTile.java
@@ -1,0 +1,56 @@
+package com.aem.ford.core.models;
+
+/**
+ * ProductTile interface defines the contract for accessing product details
+ * such as name, price, category, availability, image, and description.
+ * Implementations should provide logic to retrieve these properties.
+ * 
+ * @author Manojkumar
+ * @since 11/06/2025
+ * @version 1.0
+ */
+public interface ProductTile {
+
+    /**
+     * Gets the product name.
+     * @return the product name as a String
+     */
+    String getProductName();
+
+    /**
+     * Gets the product price.
+     * @return the product price as a String
+     */
+    String getPrice();
+
+    /**
+     * Gets the product category.
+     * @return the product category as a String
+     */
+    String getCategory();
+
+    /**
+     * Gets the product availability status.
+     * @return the product availability as a String
+     */
+    String getAvailability();
+
+    /**
+     * Gets the product image file reference.
+     * @return the image file reference as a String
+     */
+    String getImage();
+
+    /**
+     * Gets the product description.
+     * @return the product description as a String
+     */
+    String getDescription();
+
+    /**
+     * Checks if all product properties are empty or null.
+     * @return true if all properties are empty or null, false otherwise
+     */
+    boolean isEmpty();
+
+}

--- a/core/src/main/java/com/aem/ford/core/models/impl/ProductTileImpl.java
+++ b/core/src/main/java/com/aem/ford/core/models/impl/ProductTileImpl.java
@@ -1,0 +1,142 @@
+package com.aem.ford.core.models.impl;
+
+import com.aem.ford.core.models.ProductTile;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Implementation of the ProductTile Sling Model.
+ * <p>
+ * This model adapts from {@link SlingHttpServletRequest} and provides product
+ * details
+ * such as name, price, category, availability, image, and description by
+ * reading from
+ * the current page's content resource.
+ * 
+ * @author ManojKumar
+ * @since 11/06/2025
+ * @version 1.0
+ */
+@Model(adaptables = SlingHttpServletRequest.class, adapters = ProductTile.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class ProductTileImpl implements ProductTile {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ProductTileImpl.class);
+
+    @Self
+    private SlingHttpServletRequest request;
+    
+    private String productName;
+    private String price;
+    private String category;
+    private String availability;
+    private String image;
+    private String description;
+
+    /**
+     * Initializes the model by extracting product properties from the current
+     * page's content resource.
+     */
+    @PostConstruct
+    protected void init() {
+        LOG.info("Product_Tile: Initializing ProductTileImpl model");
+        PageManager pageManager = request.getResourceResolver().adaptTo(PageManager.class);
+        if (pageManager != null) {
+            LOG.info("Product_Tile: PageManager found");
+            Page currentPage = pageManager.getContainingPage(request.getResource());
+            if (currentPage != null && currentPage.getContentResource() != null) {
+                LOG.info("Product_Tile: Current page and content resource found: {}", currentPage.getPath());
+                Resource content = currentPage.getContentResource();
+                // Retrieve product properties from the content resource's value map
+                productName = content.getValueMap().get("productName", "");
+                price = content.getValueMap().get("price", "");
+                category = content.getValueMap().get("category", "");
+                availability = content.getValueMap().get("availability", "");
+                LOG.info("Product_Tile: Loaded productName='{}', price='{}', category='{}', availability='{}'",
+                        productName, price, category, availability);
+                image = content.getValueMap().get("fileReference", "");
+                description = content.getValueMap().get("description", "");
+                LOG.info("Product_Tile: Loaded description='{}'", description);
+            } else {
+                LOG.info("Product_Tile: Current page or content resource is null");
+            }
+        } else {
+            LOG.info("Product_Tile: PageManager is null");
+        }
+    }
+
+    /**
+     * @return the product name
+     */
+    @Override
+    public String getProductName() {
+        return productName;
+    }
+
+    /**
+     * @return the product price
+     */
+    @Override
+    public String getPrice() {
+        return price;
+    }
+
+    /**
+     * @return the product category
+     */
+    @Override
+    public String getCategory() {
+        return category;
+    }
+
+    /**
+     * @return the product availability
+     */
+    @Override
+    public String getAvailability() {
+        return availability;
+    }
+
+    /**
+     * @return the product image file reference
+     */
+    @Override
+    public String getImage() {
+        return image;
+    }
+
+    /**
+     * @return the product description
+     */
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Checks if all product properties are empty.
+     * 
+     * @return true if all properties are empty or null, false otherwise
+     */
+    @Override
+    public boolean isEmpty() {
+        boolean empty = (productName == null || productName.trim().isEmpty()) &&
+                (price == null || price.trim().isEmpty()) &&
+                (category == null || category.trim().isEmpty()) &&
+                (availability == null || availability.trim().isEmpty()) &&
+                (image == null || image.trim().isEmpty()) &&
+                (description == null || description.trim().isEmpty());
+        LOG.info("Product_Tile: isEmpty evaluated to {}", empty);
+        return empty;
+    }
+
+}

--- a/core/src/test/java/com/aem/ford/core/models/impl/ProductTileImplTest.java
+++ b/core/src/test/java/com/aem/ford/core/models/impl/ProductTileImplTest.java
@@ -1,0 +1,62 @@
+package com.aem.ford.core.models.impl;
+
+import com.aem.ford.core.models.ProductTile;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ProductTileImpl}.
+ * Tests the ProductTile Sling Model for correct property mapping and empty state.
+ * 
+ * @author Manojkumar
+ * @since 11/06/2025
+ * @version 1.0
+ */
+@ExtendWith(AemContextExtension.class)
+public class ProductTileImplTest {
+
+    private final AemContext context = new AemContext();
+
+    /**
+     * Sets up the test context by registering the ProductTile model and loading test JSON content.
+     */
+    @BeforeEach
+    void setUp() {
+        context.addModelsForClasses(ProductTile.class);
+        context.load().json("/product-tile/product-tile.json", "/content");
+    }
+
+    /**
+     * Tests that the ProductTile model correctly adapts and returns expected product properties.
+     */
+    @Test
+    void testProductTileModel() {
+        context.currentResource("/content/Product-Page"); 
+        ProductTile productTile = context.request().adaptTo(ProductTile.class);
+        assertNotNull(productTile, "ProductTile should not be null");
+        assertEquals("Ford Mustang", productTile.getProductName(), "Product name should match");
+        assertEquals("$55,000", productTile.getPrice(), "Product price should match");
+        assertEquals("Performance", productTile.getCategory(), "Product category should match");
+        assertEquals("In Stock", productTile.getAvailability(), "Product availability should match");
+        assertEquals("/content/dam/ford/mustang.jpg", productTile.getImage(), "Product image should match");
+        assertEquals("A classic American muscle car with modern features.", productTile.getDescription(), "Product description should match");
+        assertFalse(productTile.isEmpty(), "ProductTile should not be empty");
+    }
+
+    /**
+     * Tests that the ProductTile model returns empty when resource has no product properties.
+     */
+    @Test
+    void testEmptyProductTile() {
+        // Point to an empty or non-existing resource
+        context.currentResource("/content/empty");
+        ProductTile productTile = context.request().adaptTo(ProductTile.class);
+        assertNotNull(productTile, "ProductTile should not be null for empty resource");
+        assertTrue(productTile.isEmpty(), "ProductTile should be empty for missing properties");
+
+    }
+}

--- a/core/src/test/resources/product-tile/product-tile.json
+++ b/core/src/test/resources/product-tile/product-tile.json
@@ -1,0 +1,18 @@
+{
+  "Product-Page": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "productName": "Ford Mustang",
+      "price": "$55,000",
+      "category": "Performance",
+      "availability": "In Stock",
+      "fileReference": "/content/dam/ford/mustang.jpg",
+      "description": "A classic American muscle car with modern features."
+    }
+  },
+  "empty": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {}
+  }
+}

--- a/ui.apps/src/main/content/jcr_root/apps/ford/components/content/product-tile/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/ford/components/content/product-tile/.content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root
+    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Product Tile"
+    componentGroup="Task"
+    sling:resourceSuperType="wcm/foundation/components/responsivegrid">
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/ford/components/content/product-tile/product-tile.html
+++ b/ui.apps/src/main/content/jcr_root/apps/ford/components/content/product-tile/product-tile.html
@@ -1,0 +1,14 @@
+<sly
+  data-sly-use.productTile="com.aem.ford.core.models.ProductTile"
+  data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html"
+  data-sly-test.hasContent="${!productTile.empty}">
+
+  <sly data-sly-test="${productTile.productName}"><h1>${productTile.productName}</h1></sly>
+  <sly data-sly-test="${productTile.price}"><p>${productTile.price}</p></sly>
+  <sly data-sly-test="${productTile.category}"> <p>${productTile.category}</p></sly>
+  <sly data-sly-test="${productTile.availability}"><p>${productTile.availability}</p> </sly>
+  <sly data-sly-test="${productTile.description}"><p>${productTile.description}</p></sly>
+  <sly data-sly-test="${productTile.image}"> <img src="${productTile.image}" alt="${productTile.productName}" /></sly>
+  
+</sly>
+<sly data-sly-call="${placeholderTemplate.placeholder @ isEmpty=!hasContent}"></sly>


### PR DESCRIPTION
- Created `ProductTile` Sling Model interface and implementation
- Added JUnit test class `ProductTileImplTest` with corresponding JSON test data
- Introduced new AEM component `product-tile` with HTL rendering 
- Updated `core/pom.xml` to include Xerces dependency for XML support in tests

**Files Added:**

- core/src/main/java/com/aem/ford/core/models/ProductTile.java
- core/src/main/java/com/aem/ford/core/models/impl/ProductTileImpl.java
- core/src/test/java/com/aem/ford/core/models/impl/ProductTileImplTest.java
- core/src/test/resources/product-tile/product-tile.json
- ui.apps/src/main/content/jcr_root/apps/ford/components/content/product-tile/.content.xml
- ui.apps/src/main/content/jcr_root/apps/ford/components/content/product-tile/product-tile.html

**Files Updated**

- core/pom.xml
